### PR TITLE
Improve site navigation with quick links

### DIFF
--- a/enhanced-frame-styles.css
+++ b/enhanced-frame-styles.css
@@ -31,6 +31,7 @@
     transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     cursor: pointer;
     overflow: hidden;
+    will-change: transform, opacity;
 }
 
 /* Interactive border animation */

--- a/index.html
+++ b/index.html
@@ -148,6 +148,13 @@
 </head>
 
 <body>
+    <nav id="quick-nav">
+        <a href="#section-padres">Padres</a>
+        <a href="#section-programa">Programa</a>
+        <a href="#section-vestimenta">Vestimenta</a>
+        <a href="#section-regalos">Regalos</a>
+        <a href="#section-rsvp">RSVP</a>
+    </nav>
     <!-- Background Particles - Always visible -->
     <div class="background-particles"></div>
     <div class="particle-layer-1"></div>
@@ -219,12 +226,12 @@
                         </div>
                     </div>
 
-                    <div class="content-block">
+                    <div class="content-block" id="section-padres">
                         <h2 class="section-title">Padres</h2>
                         <p id="padres-names" class="names-list"></p>
                     </div>
 
-                    <div class="content-block">
+                    <div class="content-block" id="section-padrinos">
                         <h2 class="section-title">Padrinos</h2>
                         <p id="padrinos-names" class="names-list"></p>
                     </div>
@@ -239,7 +246,7 @@
 
                     <div class="elegant-divider"></div>
 
-                    <div class="content-block">
+                    <div class="content-block" id="section-programa">
                         <h2 class="section-title">Programa</h2>
                         <div id="program-timeline" class="timeline">
                             <!-- Timeline items will be injected here -->
@@ -248,21 +255,21 @@
 
                     <div class="elegant-divider"></div>
 
-                    <div class="content-block">
+                    <div class="content-block" id="section-vestimenta">
                         <h2 class="section-title">Vestimenta</h2>
                         <p id="dress-code" class="info-text"></p>
                     </div>
 
                     <div class="elegant-divider"></div>
 
-                    <div class="content-block">
+                    <div class="content-block" id="section-regalos">
                         <h2 class="section-title">Regalos</h2>
                         <p id="gifts-info" class="info-text"></p>
                     </div>
 
                     <div class="elegant-divider"></div>
 
-                    <div class="content-block rsvp-section">
+                    <div class="content-block rsvp-section" id="section-rsvp">
                         <a id="rsvp-button" href="#" target="_blank" class="jewel-button">Confirmar Asistencia</a>
                     </div>
                 </div>

--- a/interactive-frame.js
+++ b/interactive-frame.js
@@ -10,15 +10,17 @@ document.addEventListener("DOMContentLoaded", function () {
   let ticking = false;
 
   // Intersection Observer for frame visibility
+  let frameActivated = false;
+
   const frameObserver = new IntersectionObserver(
-    (entries) => {
+    (entries, observer) => {
       entries.forEach((entry) => {
-        if (entry.isIntersecting) {
+        if (entry.isIntersecting && !frameActivated) {
+          frameActivated = true;
           entry.target.classList.add("frame-visible");
-          // Trigger sparkle effect when frame comes into view
           entry.target.style.setProperty("--sparkle-opacity", "0.5");
-        } else {
-          entry.target.classList.remove("frame-visible");
+          observer.unobserve(entry.target);
+        } else if (!entry.isIntersecting && frameActivated) {
           entry.target.style.setProperty("--sparkle-opacity", "0");
         }
       });

--- a/main.js
+++ b/main.js
@@ -343,6 +343,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Scene 2: Content Block Fade-in + Micro-parallax + Pop effect
   gsap.utils.toArray(".content-block").forEach((block) => {
+    const updateY = gsap.quickSetter(block, "y", "px");
     gsap.fromTo(
       block,
       { opacity: 0, y: 50, scale: 0.95 }, // Initial scale for pop effect
@@ -360,7 +361,7 @@ document.addEventListener("DOMContentLoaded", () => {
           onUpdate: (self) => {
             const progress = self.progress;
             const parallaxAmount = (1 - progress) * 30; // Increased parallax
-            gsap.to(block, { y: parallaxAmount, duration: 0.2, ease: "none" });
+            updateY(parallaxAmount);
           },
         },
       }

--- a/styles.css
+++ b/styles.css
@@ -17,6 +17,33 @@
     --pearl: #fffdf8;
 }
 
+/* Quick navigation menu */
+#quick-nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    gap: 15px;
+    background: rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(5px);
+    padding: 10px 0;
+    z-index: 9999;
+}
+
+#quick-nav a {
+    font-family: 'Playfair Display', serif;
+    color: var(--color-red);
+    text-decoration: none;
+    font-weight: bold;
+}
+
+#quick-nav a:hover {
+    text-decoration: underline;
+}
+
+
 html {
     scroll-behavior: smooth;
 }
@@ -1565,6 +1592,7 @@ body {
     transform: translateY(30px);
     transition: opacity var(--transition-speed) ease-out, transform var(--transition-speed) ease-out;
     margin-bottom: 40px;
+    will-change: transform, opacity;
 }
 
 .content-block.is-in-view {


### PR DESCRIPTION
## Summary
- add a fixed quick navigation bar with anchor links
- add IDs to key invitation sections
- keep frame visible once it enters view and hardware-accelerate transitions
- use quickSetter for parallax updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c355c08448330988ecf8830b0f5b4