### PR TITLE
Kill intro ScrollTrigger after first run

### DIFF
--- a/main.js
+++ b/main.js
@@ -242,6 +242,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
           // Celebration burst when entering scene 2
           fireworksController.celebrationBurst();
+
+          // Disable ScrollTrigger after first play to conserve resources
+          if (introTimeline.scrollTrigger) {
+            introTimeline.scrollTrigger.kill();
+          }
         },
         onEnterBack: () => {
           // Smooth transition back to scene1


### PR DESCRIPTION
## Summary
- disable ScrollTrigger once the gift box animation finishes to avoid rerunning the intro

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c481d81f88330bad5ff61fbd09cbd