### PR TITLE
Fix invitation offset after confetti

### DIFF
--- a/main.js
+++ b/main.js
@@ -245,7 +245,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
           // Disable ScrollTrigger after first play to conserve resources
           if (introTimeline.scrollTrigger) {
-            introTimeline.scrollTrigger.kill();
+            introTimeline.scrollTrigger.kill(true);
           }
         },
         onEnterBack: () => {
@@ -370,7 +370,7 @@ document.addEventListener("DOMContentLoaded", () => {
   // Quick navigation: skip intro and scroll to section
   function skipIntroAndScroll(target) {
     if (introTimeline.scrollTrigger && !introTimeline.scrollTrigger.disabled) {
-      introTimeline.scrollTrigger.kill();
+      introTimeline.scrollTrigger.kill(true);
       introTimeline.progress(1);
     }
     gsap.set(scene1, { opacity: 0 });


### PR DESCRIPTION
## Summary
- remove leftover ScrollTrigger pin spacer when the intro ends
- also clear pinning if intro is skipped via quick navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c4ac58e988330b0c2e4064e5db703