### PR TITLE
feat: Improve scroll animation and transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,6 +284,7 @@
     <!-- GSAP and ScrollTrigger CDN -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/ScrollTrigger.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/ScrollToPlugin.min.js"></script>
     <!-- Fireworks and Canvas Confetti Libraries -->
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
     <script src="https://unpkg.com/fireworks-js@2.x/dist/index.umd.js"></script>


### PR DESCRIPTION
The previous scroll implementation for the quick navigation was abrupt and visually jarring. It used `gsap.set` to instantly change the view and then relied on the browser's native `scrollIntoView`, which created a poor user experience you described as "slow and ugly".

This commit refactors the scroll functionality to provide a smooth, animated experience:

- Adds the GSAP ScrollToPlugin to enable programmatic, smooth scrolling.
- Replaces the `skipIntroAndScroll` function with a new implementation that uses a GSAP timeline.
- The new timeline smoothly fades out the initial scene, fades in the invitation content, and animates the scroll to the target section.
- This creates a seamless and elegant transition that directly addresses your feedback.